### PR TITLE
UI: Onboarding no roles dashboard button + auto-select contest (Issue #4)

### DIFF
--- a/frontend/src/components/OnboardingFlow.tsx
+++ b/frontend/src/components/OnboardingFlow.tsx
@@ -16,6 +16,8 @@ export default function OnboardingFlow() {
     const [error, setError] = useState('');
     const [selectedContestId, setSelectedContestId] = useState<number | ''>('');
 
+    const router = useRouter();
+
     useEffect(() => {
         const fetchAvailableRoles = async () => {
             try {
@@ -40,7 +42,16 @@ export default function OnboardingFlow() {
         fetchAvailableRoles();
     }, []);
 
-    const router = useRouter();
+    // Auto-seleciona concurso se houver apenas um
+    useEffect(() => {
+        if (!selectedContestId && roles.length > 0) {
+            // Agrupa contests válidos
+            const uniqueContestIds = Array.from(new Set(roles.map(r => r.contest?.id).filter(Boolean)));
+            if (uniqueContestIds.length === 1) {
+                setSelectedContestId(uniqueContestIds[0] as number);
+            }
+        }
+    }, [roles, selectedContestId]);
 
     const contests = useMemo(() => {
         const map = new Map<number, string>();
@@ -93,7 +104,19 @@ export default function OnboardingFlow() {
 
     if (isLoading) return <p>Carregando cargos disponíveis...</p>;
     if (error) return <p className="text-red-600">{error}</p>;
-    if (roles.length === 0) return <p>Não há cargos disponíveis para nova inscrição no momento.</p>;
+    if (roles.length === 0) {
+        return (
+            <div className="text-center space-y-4">
+                <p>Não há cargos disponíveis para nova inscrição no momento.</p>
+                <button
+                    className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700"
+                    onClick={() => router.push('/dashboard')}
+                >
+                    Voltar para o painel
+                </button>
+            </div>
+        );
+    }
 
     return (
         <div className="bg-surface p-8 rounded-xl shadow-md space-y-8 max-w-2xl mx-auto">


### PR DESCRIPTION
## UI/UX: onboarding dashboard button and autoselect contest for available roles (Issue #4)

- When no available roles, displays a button for the user to return to the dashboard (/dashboard) in addition to the message.
- Auto-selects the contest in the onboarding dropdown if there's only one option, so onboarding is smoother for a single contest/cargo situation.
- Guards and UX refinements maintained for contest grouping and 409 conflict handling.

Tested scenario:
- If GET /study/available-roles returns one role, user sees the contest/cargo directly; if empty, the button to return is visible.

Closes #4 when merged.